### PR TITLE
Add logo explanation page, link from About page

### DIFF
--- a/about-logo.md
+++ b/about-logo.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: About the Logo
+---
+
+# About the Logo
+
+### From the designer
+
+The *apostilb* logo features an illustration of a bulb set against a row of text on a printed page. The bulb represents the aim of *apostilb*, to highlight the essence of a scientific paper. It also underscores the value of marginalia in literature, in general, and of lay summaries of technical works, in particular. The bulb serves as a gateway into the depths of the text, catching the eye of the passing reader who’s unfamiliar with the content, courting them to take the leap from mere browsing to in-depth study and understanding.
+
+The placement of the bulb – offset from the centre – serves as a reminder that while it is the focus of attention, it lies in the margins of the main text and is but a gist. Inside the bulb, a symmetrical filament spells “asb”, the symbol for apostilb – an old unit of luminance. The bulb itself makes up the website’s favicon.
+
+The logo is designed in the minimalist style, using simple shapes and a monochrome colour scheme. This reflects the theme of the project: to distill complex scientific literature into easily digestible bites. The image is built using inverted colours, with the bulb aptly shining white light upon a dark grey background. The strong contrast between the two colours symbolizes the utility and benefit of lay summaries as companions to academic scholarly communication – in making visible the wealth of information that may otherwise remain obscure and unintelligible, locked in the archives of the scientific literature.
+
+&mdash; Aditya Rao
+
+---
+
+- [The logo design process, including early mockups](https://imgur.com/a/jOaDB)
+- [Other work by Aditya](http://stringsandwings.imgur.com/)

--- a/about.md
+++ b/about.md
@@ -22,3 +22,7 @@ Lay science summaries have become topical in the scicomm community. Science enth
 2. `apostilb`: a unit of luminance
 
     With our *apostils* we are trying to shine a light on the original scientific content, seeing it in a new and hopefully universally intelligible light.
+
+### About the logo
+
+The designer of the apostilb logo [describes its design and significance](/about-logo).


### PR DESCRIPTION
@neuroamanda: I've added the page (with some further edits) and linked to it from the `About` page. It won't appear, by intention, in the sidebar.

Let me know if you're happy with this, and I'm merge the pull request.
